### PR TITLE
Hotfix for mounted guns and sentries

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -28,7 +28,7 @@
 
 	fire_sound = 'sound/weapons/guns/fire/hmg2.ogg'
 	reload_sound = 'sound/weapons/guns/interact/minigun_cocked.ogg'
-
+	caliber = CALIBER_10X30
 	default_ammo_type = /obj/item/ammo_magazine/tl102
 
 	scatter = 10
@@ -73,7 +73,7 @@
 	icon_state = "entrenched"
 
 	default_ammo_type = /obj/item/ammo_magazine/tl102/hsg_nest
-
+	caliber = CALIBER_10X30
 	attachable_allowed = list(/obj/item/attachable/scope/unremovable/tl102/nest)
 	starting_attachment_types = list(
 		/obj/item/attachable/scope/unremovable/tl102/nest,

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -8,7 +8,7 @@
 
 	max_integrity = 200
 	soft_armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 80, ACID = 50)
-
+	caliber = CALIBER_10X28
 	fire_delay = 0.6 SECONDS
 	extra_delay = 0.6 SECONDS
 	burst_delay = 0.3 SECONDS
@@ -222,7 +222,7 @@
 	name = "\improper ST-580 point defense sentry"
 	desc = "A deployable, automated turret with AI targeting capabilities. This is a lightweight portable model meant for rapid deployment and point defense. Armed with an light, high velocity machine gun and a 100-round drum magazine."
 	icon_state = "minisentry"
-
+	caliber = CALIBER_10X20
 	max_shells = 600
 	knockdown_threshold = 80
 
@@ -250,6 +250,7 @@
 	icon_state = "sentry"
 	turret_flags = TURRET_HAS_CAMERA|TURRET_ON|TURRET_IMMOBILE|TURRET_SAFETY|TURRET_RADIAL
 	max_shells = 100
+	caliber = CALIBER_10X28
 
 	ammo_datum_type = /datum/ammo/bullet/turret/gauss
 	default_ammo_type = /obj/item/ammo_magazine/sentry


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some back-end code to make sure all the mounted guns and sentries can be reloaded as per the norm.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mounted guns won't be broke by the magazine refactor
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Added caliber definitions to mounted guns and sentries. Should be everything that is actually under the purview of magazine-based weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
