### PR TITLE
Allows Mag Harness to act like a pistol lace for longarms.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -593,11 +593,41 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 /obj/item/attachable/magnetic_harness
 	name = "magnetic harness"
-	desc = "A magnetically attached harness kit that attaches to the rail mount of a weapon. When dropped, the weapon will sling to a TGMC armor."
+	desc = "A magnetically attached harness kit that attaches to the rail mount of a weapon. When dropped, the weapon will sling to a TGMC armor. You can also tighten it around your shoulder to keep yourself from dropping it."
 	icon_state = "magnetic"
 	slot = ATTACHMENT_SLOT_RAIL
 	pixel_shift_x = 13
+	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
+	attachment_action_type = /datum/action/item_action/toggle
 
+/obj/item/attachable/magnetic_harness/activate(mob/living/user, turn_off)
+	if(lace_deployed)
+		to_chat(user, span_notice("You loosen the [src]."))
+		DISABLE_BITFIELD(master_gun.flags_item, NODROP)
+		to_chat(user, span_notice("You feel the [src] loosen around your shoulder!"))
+		playsound(user, 'sound/weapons/fistunclamp.ogg', 25, 1, 7)
+		icon_state = "magnetic"
+	else if(turn_off)
+		return
+	else
+		if(user.do_actions)
+			return
+		if(!do_after(user, 0.5 SECONDS, TRUE, src, BUSY_ICON_BAR))
+			return
+		to_chat(user, span_notice("You tighten the [src]."))
+		ENABLE_BITFIELD(master_gun.flags_item, NODROP)
+		to_chat(user, span_warning("You feel the [src] close around your shoulder!"))
+		playsound(user, 'sound/weapons/fistclamp.ogg', 25, 1, 7)
+		icon_state = "magnetic"
+
+	lace_deployed = !lace_deployed
+
+	for(var/i in master_gun.actions)
+		var/datum/action/action_to_update = i
+		action_to_update.update_button_icon()
+
+	update_icon()
+	return TRUE
 
 /obj/item/attachable/scope
 	name = "rail scope"
@@ -1220,8 +1250,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 	update_icon()
 	return TRUE
-
-
 
 /obj/item/attachable/burstfire_assembly
 	name = "burst fire assembly"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds an activatable button to the Magnetic Harness, allowing it to act similarly to a pistol lace.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Every time you are forced to drop your gun it gets unlinked from whatever pack you might have hooked it to. The enemy cannot force you to drop your gun if you disable your hand.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Magnetic harness can now be used as a lace for any gun that has a usable rail slot and can mount it. Mostly a QoL for powerpack and ammopack users.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
