### PR TITLE
Buffs charge rate of Powerpack

### DIFF
--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -107,7 +107,7 @@
 	slowdown = 0.3
 	maxcharge = 15000
 	self_recharge = TRUE
-	charge_amount = 32
+	charge_amount = 300
 	charge_delay = 2 SECONDS
 
 ///Handles draining power from the powerpack, returns the value of the charge drained to MouseDrop where it's added to the cell.


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This is to bring the powerpack up to a similar level as the Ammopack for mission longevity. This is 2 percent of max charge every 2 seconds
## Why It's Good For The Game
Where the Ammopack holds a staggering amount of ammo for a relative few guns, the powerpack is compatible with a wider variety and now recharges much faster. You can still run out of shots under constant fire just as the ammopack can (and I have on one occasion), but neither should be viewed as superior to the other now.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Powerpack charge amount increased from 32 watts every 2 seconds to 300 watts every 2 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
