### PR TITLE
Buffs defib window, nerfs Powerpack charge delay

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -321,7 +321,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define LIMB_METAL_AMOUNT 125
 
 //How long it takes for a human to become undefibbable
-#define TIME_BEFORE_DNR 150 //In life ticks, multiply by 2 to have seconds
+#define TIME_BEFORE_DNR 450 //In life ticks, multiply by 2 to have seconds
 
 
 //species_flags

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -108,7 +108,7 @@
 	maxcharge = 15000
 	self_recharge = TRUE
 	charge_amount = 300
-	charge_delay = 2 SECONDS
+	charge_delay = 5 SECONDS
 
 ///Handles draining power from the powerpack, returns the value of the charge drained to MouseDrop where it's added to the cell.
 /obj/item/cell/lasgun/volkite/powerpack/proc/use_charge(mob/user, amount = 0, mention_charge = TRUE)


### PR DESCRIPTION
…tes. Increase charge delay of m-70 powerpack from 2 seconds to 5 seconds.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Five minutes from death to permadeath is a really harsh timer with the way the AI will naturally spread out and keep constant pressure on marines. Too harsh when at any time a random warrior can show up and decide, out of a dozen marines, to focus the one dude holding a defib when the guys he's trying to revive are already near permadeath.

Also I unintentionally made Powerpacks charge way too fast, and this should bring them back in line. No more almost infinite overcharge with no meaningful breaks.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Defib window increased from 5 minutes to 15
balance: Powerpack charge delay increased from 2 seconds to 5 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
