### PR TITLE
Combines Xenomate and Optical Imager, adds it to clothing vendor, adds two improved versions to Req.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1357,6 +1357,7 @@
 			/obj/item/clothing/head/tgmcberet = -1,
 			/obj/item/clothing/glasses/mgoggles = -1,
 			/obj/item/clothing/glasses/mgoggles/prescription = -1,
+			/obj/item/clothing/glasses/hud/xenohud = -1,
 		),
 		"Masks" = list(
 			/obj/item/clothing/mask/rebreather/scarf = -1,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1358,6 +1358,7 @@
 			/obj/item/clothing/glasses/mgoggles = -1,
 			/obj/item/clothing/glasses/mgoggles/prescription = -1,
 			/obj/item/clothing/glasses/hud/xenohud = -1,
+			/obj/item/clothing/glasses/night/imager_goggles = -1,
 		),
 		"Masks" = list(
 			/obj/item/clothing/mask/rebreather/scarf = -1,

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -138,16 +138,29 @@
 	actions_types = null
 
 /obj/item/clothing/glasses/hud/xenohud
-	name = "XenoMate HUD"
-	desc = "A heads-up display that scans any nearby xenomorph's data."
+	name = "XenoMate optical imager goggles"
+	desc = "A heads-up display that scans any nearby xenomorph's data, and increases the visibility of dimly lit terrain."
 	icon_state = "securityhud"
 	deactive_state = "degoggles_sec"
 	species_exception = list(/datum/species/robot)
 	sprite_sheets = list("Combat Robot" = 'icons/mob/species/robot/glasses.dmi')
 	flags_armor_protection = NONE
+	darkness_view = 2
 	toggleable = TRUE
 	hud_type = DATA_HUD_XENO_STATUS
 	actions_types = list(/datum/action/item_action/toggle)
+
+/obj/item/clothing/glasses/hud/xenohud/night
+	name = "XenoMate enhanced imager goggles"
+	desc = "A heads-up display that scans any nearby xenomorph's data. This model allows greater visibility even in the absence of light."
+	darkness_view = 14
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+
+/obj/item/clothing/glasses/hud/xenohud/night/meson
+	name = "XenoMate multi-stage imager goggles"
+	desc = "A heads-up display that scans any nearby xenomorph's data. This improved model has meson imaging to highlight terrain."
+	vision_flags = SEE_TURFS
+	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 
 /obj/item/clothing/glasses/hud/painhud
 	name = "Pain HUD"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -727,9 +727,14 @@ ARMOR
 	cost = 5
 
 /datum/supply_packs/armor/imager_goggle
-	name = "Optical Imager Goggles"
-	contains = list(/obj/item/clothing/glasses/night/imager_goggles)
+	name = "XenoMate Enhanced Imager Goggles"
+	contains = list(/obj/item/clothing/glasses/hud/xenohud/night)
 	cost = 5
+
+/datum/supply_packs/armor/imager_goggle/meson
+	name = "XenoMate Multi-Stage Imager Goggles"
+	contains = list(/obj/item/clothing/glasses/hud/xenohud/night/meson)
+	cost = 10
 
 /datum/supply_packs/armor/riot
 	name = "Heavy Riot Armor Set"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The TGMC has come to expect power failures and xeno infestations, and has moved to provide troops with a low-light imager and xenomorph data hud in a single wearable unit. Field testing has also now begun of two sequential improvements on the technology, the first improving on the low-light enhancement technology, and the second improving upon it further and adding terrain highlight functionality via a multistage meson scanner. Should field tests prove successful, the TGMC is considering making the improved imager and multi-stage imager available as standard issue to squad leaders, engineers, and field commanders.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to tell whether or not your enemy is dead beneath a pile of dead bugs is far less of a balance concern when it's not a player on the other end. Besides this, it makes night vision optics more available throughout a round rather than relying on specialist kits which you may not want the weapons or armor from, or expensive random chance loot boxes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added XenoMate Enhanced Imager Goggles, which allow you to see further than the standard model. These replace the old imager goggles as a 5 point req item
add: Added XenoMate Multi-Stage Imager Goggles, which do not rely on ambient light and also have meson functionality. They cost 10 points through req.
balance: Gave xenomate HUDs the same capability as the current optical imager goggles and added them to the clothing vendor under headwear. You cannot put them inside goggles, but I added the old imager goggles too for those who want to combine them with goggles for their drip.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
