### PR TITLE
Fixes heavy laser being unloadable

### DIFF
--- a/code/__DEFINES/calibers.dm
+++ b/code/__DEFINES/calibers.dm
@@ -79,6 +79,7 @@
 #define CALIBER_10X20 "10x20mm" //Minisentry
 #define CALIBER_10X30 "10x30mm caseless"
 #define CALIBER_20 "20mm" //Dualcannon
+#define CALIBER_HEAVY_LASER "Heavy Laser"//Mounted Heavy Laser
 
 ///Unmanned vehicles
 #define CALIBER_11X35 "11x35mm"

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -179,7 +179,7 @@
 
 	fire_sound = 'sound/weapons/guns/fire/tank_flamethrower.ogg'
 	reload_sound = 'sound/weapons/guns/interact/minigun_cocked.ogg'
-
+	caliber = CALIBER_HEAVY_LASER
 	default_ammo_type = /obj/item/ammo_magazine/heavy_laser
 
 	scatter = 10

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -109,6 +109,7 @@
 	name = "heavy-duty weapon laser cell"
 	desc = "A cell with enough charge to contain 15 heavy laser shots for the TE-9001. This cannot be recharged."
 	w_class = WEIGHT_CLASS_BULKY
+	caliber = CALIBER_HEAVY_LASER
 	flags_magazine = NONE
 	max_rounds = 15
 	default_ammo = /datum/ammo/energy/lasgun/marine/heavy_laser


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does exactly what it says on the tin
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes yet another mounted weapon
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a new define, CALIBER_HEAVY_LASER, which should cover any future weapons that use the same caliber as the mounted heavy laser
fix: Mounted Heavy Laser and its ammo now have a caliber definition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
