### PR TITLE
Increases squad role skills, misc QoL and balance changes, merc drip

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -70,9 +70,9 @@
 
 //medical skill
 #define SKILL_MEDICAL_UNTRAINED 0
-#define SKILL_MEDICAL_NOVICE 1 //Premed or paramedic. Recognizing chemicals. SL, survivors.
-#define SKILL_MEDICAL_PRACTICED 2 //Beginning intern, Squad Corpsman, IO.
-#define SKILL_MEDICAL_COMPETENT 3 //General practitioner. Survivor doc, early synth.
+#define SKILL_MEDICAL_NOVICE 1 //Premed or paramedic. Recognizing chemicals.
+#define SKILL_MEDICAL_PRACTICED 2 //Beginning intern, IO, Survivors, Squad Marines
+#define SKILL_MEDICAL_COMPETENT 3 //General practitioner. Survivor doc, Squad Corpsman, early synth.
 #define SKILL_MEDICAL_EXPERT 4 //Surgeons. CMO, MO, synth.
 #define SKILL_MEDICAL_MASTER 5 //Modern-day Aesculapius. Spatial agent only now.
 //higher levels means faster syringe use and better defibrillation
@@ -81,8 +81,8 @@
 //surgery skill
 #define SKILL_SURGERY_DEFAULT 0 //untrained, really slow
 #define SKILL_SURGERY_AMATEUR 1 //basic notions of first aid and biology (SL, SO)
-#define SKILL_SURGERY_TRAINED 2 //semi-professional surgery (Squad Corpsman)
-#define SKILL_SURGERY_PROFESSIONAL 3 //professional but unspecialized (Researcher)
+#define SKILL_SURGERY_TRAINED 2 //semi-professional surgery (Survivor doc)
+#define SKILL_SURGERY_PROFESSIONAL 3 //professional but unspecialized (Researcher, Squad Corpsman)
 #define SKILL_SURGERY_EXPERT 4 //specialized (Doctor, CMO)
 #define SKILL_SURGERY_MASTER 5 //to be implemented, perhaps instant surgery
 //higher levels means faster surgery.

--- a/code/datums/elements/shrapnel_removal.dm
+++ b/code/datums/elements/shrapnel_removal.dm
@@ -35,7 +35,7 @@
 		if(!do_after(user, do_after_time * (SKILL_MEDICAL_PRACTICED - skill), TRUE, target, BUSY_ICON_UNSKILLED))
 			return
 	user.visible_message(span_notice("[user] starts searching for shrapnel in [target] with the [removaltool]."), span_notice("You start searching for shrapnel in [target] with the [removaltool]."))
-	if(!do_after(user, do_after_time, TRUE, target, BUSY_ICON_MEDICAL))
+	if(!do_after(user, do_after_time / (skill + 0.5), TRUE, target, BUSY_ICON_MEDICAL))
 		to_chat(user, span_notice("You stop searching for shrapnel in [target]"))
 		return
 	remove_shrapnel(user, target, targetlimb, skill)
@@ -62,8 +62,8 @@
 		I.unembed_ourself(FALSE)
 		if(skill < SKILL_MEDICAL_PRACTICED)
 			user.visible_message(span_notice("[user] violently rips out [I] from [target]!"), span_notice("You violently rip out [I] from [target]!"))
-			targetlimb.take_damage_limb(30 * (SKILL_MEDICAL_PRACTICED - skill), 0, FALSE, FALSE)
+			targetlimb.take_damage_limb(50 - (skill * 5), 0, FALSE, FALSE)
 		else
 			user.visible_message(span_notice("[user] pulls out [I] from [target]!"), span_notice("You pull out [I] from [target]!"))
-			targetlimb.take_damage_limb(15, 0, FALSE, FALSE)
+			targetlimb.take_damage_limb(25 - (skill * 5), 0, FALSE, FALSE)
 		break

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -46,6 +46,7 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 		<b>Duty</b>: Carry out orders made by your acting Squad Leader, deal with any threats that oppose the TGMC.
 	"}
 	minimap_icon = "private"
+	skills_type = /datum/skills/crafty //Can set up and repair metal barricades, and should be able to use tweezers, ATKs, and health analyzers.
 
 /datum/job/terragov/squad/standard/rebel
 	title = REBEL_SQUAD_MARINE
@@ -129,9 +130,9 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 	outfit = /datum/outfit/job/marine/engineer
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS
 	jobworth = list(
-		/datum/job/xenomorph = LARVA_POINTS_REGULAR, 
-		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM, 
-		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR, 
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
+		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM,
+		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR,
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 	)
 	html_description = {"
@@ -152,7 +153,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 	access = list(ACCESS_MARINE_PREP_REBEL, ACCESS_MARINE_ENGPREP_REBEL, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_REMOTEBUILD_REBEL, ACCESS_MARINE_ENGINEERING_REBEL)
 	minimal_access = list(ACCESS_MARINE_PREP_REBEL, ACCESS_MARINE_ENGPREP_REBEL, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_DROPSHIP_REBEL, ACCESS_MARINE_REMOTEBUILD_REBEL, ACCESS_MARINE_ENGINEERING_REBEL)
 	jobworth = list(
-		/datum/job/xenomorph = LARVA_POINTS_REGULAR, 
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner/rebel = SMARTIE_POINTS_MEDIUM,
 		/datum/job/terragov/silicon/synthetic/rebel = SYNTH_POINTS_REGULAR
 	)
@@ -228,9 +229,9 @@ Your squaddies will look to you when it comes to construction in the field of ba
 	outfit = /datum/outfit/job/marine/corpsman
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS
 	jobworth = list(
-		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR, 
-		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR, 
-		/datum/job/xenomorph = LARVA_POINTS_REGULAR, 
+		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR,
+		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_MEDIUM
 	)
 	html_description = {"
@@ -251,8 +252,8 @@ Your squaddies will look to you when it comes to construction in the field of ba
 	access = list(ACCESS_MARINE_PREP_REBEL, ACCESS_MARINE_MEDPREP_REBEL, ACCESS_MARINE_MEDBAY_REBEL)
 	minimal_access = list(ACCESS_MARINE_PREP_REBEL, ACCESS_MARINE_MEDPREP_REBEL, ACCESS_MARINE_MEDBAY_REBEL, ACCESS_MARINE_DROPSHIP_REBEL)
 	jobworth = list(
-		/datum/job/terragov/silicon/synthetic/rebel = SYNTH_POINTS_REGULAR, 
-		/datum/job/xenomorph = LARVA_POINTS_REGULAR, 
+		/datum/job/terragov/silicon/synthetic/rebel = SYNTH_POINTS_REGULAR,
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner/rebel = SMARTIE_POINTS_MEDIUM
 	)
 
@@ -580,8 +581,8 @@ You are also in charge of communicating with command and letting them know about
 	total_positions = 0
 	job_flags = JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS
 	jobworth = list(
-		/datum/job/xenomorph = LARVA_POINTS_REGULAR, 
-		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR, 
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
+		/datum/job/terragov/silicon/synthetic = SYNTH_POINTS_REGULAR,
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 	)
 	minimap_icon = "private"
@@ -592,7 +593,7 @@ You are also in charge of communicating with command and letting them know about
 	access = list(ACCESS_MARINE_PREP_REBEL)
 	minimal_access = list(ACCESS_MARINE_PREP_REBEL, ACCESS_MARINE_DROPSHIP_REBEL)
 	jobworth = list(
-		/datum/job/xenomorph = LARVA_POINTS_REGULAR, 
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/silicon/synthetic/rebel = SYNTH_POINTS_REGULAR,
 	)
 

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -214,7 +214,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	engineer = SKILL_ENGINEER_ENGI //to hack airlocks so they're never stuck in a room.
 	firearms = SKILL_FIREARMS_DEFAULT
 	construction = SKILL_CONSTRUCTION_METAL
-	medical = SKILL_MEDICAL_NOVICE
+	medical = SKILL_MEDICAL_PRACTICED
 
 /datum/skills/civilian/survivor/master
 	name = "Survivor"
@@ -273,12 +273,15 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_ADVANCED
 	leadership = SKILL_LEAD_BEGINNER
 	powerloader = SKILL_POWERLOADER_DABBLING
+	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
 
 /datum/skills/combat_medic
 	name = "Combat Medic"
 	leadership = SKILL_LEAD_BEGINNER
-	medical = SKILL_MEDICAL_PRACTICED
-	surgery = SKILL_SURGERY_TRAINED
+	medical = SKILL_MEDICAL_COMPETENT
+	surgery = SKILL_SURGERY_PROFESSIONAL
+	pistols = SKILL_PISTOLS_TRAINED
+	smgs = SKILL_SMGS_TRAINED
 
 /datum/skills/combat_medic/crafty
 	name = "Crafty Combat Medic"
@@ -289,8 +292,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	name = "Doctor"
 	cqc = SKILL_CQC_WEAK
 	firearms = SKILL_FIREARMS_UNTRAINED
-	medical = SKILL_MEDICAL_EXPERT
-	surgery = SKILL_SURGERY_EXPERT
+	medical = SKILL_MEDICAL_MASTER
+	surgery = SKILL_SURGERY_MASTER
 	melee_weapons = SKILL_MELEE_WEAK
 
 /datum/skills/cmo
@@ -298,8 +301,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	cqc = SKILL_CQC_WEAK
 	firearms = SKILL_FIREARMS_UNTRAINED
 	leadership = SKILL_LEAD_TRAINED
-	medical = SKILL_MEDICAL_EXPERT
-	surgery = SKILL_SURGERY_EXPERT
+	medical = SKILL_MEDICAL_MASTER
+	surgery = SKILL_SURGERY_MASTER
 	melee_weapons = SKILL_MELEE_WEAK
 	police = SKILL_POLICE_MP
 
@@ -425,6 +428,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	name = "Crafty Private"
 	construction = SKILL_CONSTRUCTION_METAL
 	engineer = SKILL_ENGINEER_METAL
+	medical = SKILL_MEDICAL_PRACTICED
+	surgery = SKILL_SURGERY_TRAINED
 
 /datum/skills/special_forces_standard
 	name = "Special Force Standard"
@@ -438,8 +443,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	engineer = SKILL_ENGINEER_PLASTEEL
 	leadership = SKILL_LEAD_EXPERT
-	medical = SKILL_MEDICAL_NOVICE
-	surgery = SKILL_SURGERY_AMATEUR
+	medical = SKILL_MEDICAL_PRACTICED
+	surgery = SKILL_SURGERY_TRAINED
 
 /datum/skills/sl/clf
 	name = "CLF leader"

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -12,7 +12,7 @@
 	throw_speed = 5
 	throw_range = 20
 	attack_verb = list("hit", "whacked", "sliced")
-	max_amount = 20
+	max_amount = 25
 	merge_type = /obj/item/stack/barbed_wire
 
 //small stack
@@ -25,7 +25,7 @@
 
 //full stack
 /obj/item/stack/barbed_wire/full
-	amount = 20
+	amount = 25
 
 /obj/item/stack/barbed_wire/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -138,7 +138,7 @@
 	singular_name = "medical gauze"
 	desc = "Some sterile gauze to wrap around bloody stumps."
 	icon_state = "brutepack"
-	heal_brute = 3
+	heal_brute = 5
 	heal_flags = BANDAGE
 
 /obj/item/stack/medical/heal_pack/gauze/generate_treatment_messages(mob/user, mob/patient, datum/limb/target_limb, success)
@@ -154,7 +154,7 @@
 	gender = PLURAL
 	singular_name = "ointment"
 	icon_state = "ointment"
-	heal_burn = 3
+	heal_burn = 5
 	heal_flags = SALVE
 
 /obj/item/stack/medical/heal_pack/ointment/generate_treatment_messages(mob/user, mob/patient, datum/limb/target_limb, success)
@@ -202,7 +202,7 @@
 	singular_name = "advanced trauma kit"
 	desc = "An advanced trauma kit for severe injuries."
 	icon_state = "traumakit"
-	heal_brute = 12
+	heal_brute = 15
 	heal_flags = BANDAGE | DISINFECT
 
 /obj/item/stack/medical/heal_pack/advanced/bruise_pack/generate_treatment_messages(mob/user, mob/patient, datum/limb/target_limb, success)
@@ -217,7 +217,7 @@
 	singular_name = "advanced burn kit"
 	desc = "An advanced treatment kit for severe burns."
 	icon_state = "burnkit"
-	heal_burn = 12
+	heal_burn = 15
 	heal_flags = SALVE | DISINFECT
 
 /obj/item/stack/medical/heal_pack/advanced/burn_pack/generate_treatment_messages(mob/user, mob/patient, datum/limb/target_limb, success)
@@ -234,7 +234,7 @@
 	amount = 5
 	max_amount = 5
 	skill_level_needed = SKILL_MEDICAL_PRACTICED
-	unskilled_delay = SKILL_TASK_TOUGH
+	unskilled_delay = SKILL_TASK_EASY
 	///How much splint health per medical skill is applied
 	var/applied_splint_health = 15
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -12,8 +12,8 @@
 */
 GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
-	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 1, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
+	new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), \
 	null, \
 	new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2), \
 	new/datum/stack_recipe("wall girder", /obj/structure/girder, 8, time = 10 SECONDS, max_per_turf = STACK_RECIPE_ONE_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_ADVANCED), \
@@ -98,9 +98,9 @@ GLOBAL_LIST_INIT(metal_radial_images, list(
 		if("barricade")
 			create_object(user, new/datum/stack_recipe("metal barricade", /obj/structure/barricade/metal, 4, time = 8 SECONDS, max_per_turf = STACK_RECIPE_ONE_DIRECTIONAL_PER_TILE, on_floor = TRUE, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("barbedwire")
-			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 2, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("barbed wire", /obj/item/stack/barbed_wire, 1, 1, 20, time = 1 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 		if("razorwire")
-			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 3, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
+			create_object(user, new/datum/stack_recipe("razor wire", /obj/item/stack/razorwire, 2, 1, 20, time = 5 SECONDS, skill_req = SKILL_CONSTRUCTION_METAL), 1)
 
 	return FALSE
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -254,6 +254,7 @@
 			/obj/item/binoculars = -1,
 			/obj/item/compass = -1,
 			/obj/item/tool/hand_labeler = -1,
+			/obj/item/stack/sandbags_empty/full = -1,
 		),
 	)
 
@@ -485,6 +486,7 @@
 			/obj/item/assembly/signaler = -1,
 			/obj/item/binoculars = -1,
 			/obj/item/compass = -1,
+			/obj/item/stack/sandbags_empty/full = -1,
 		),
 	)
 
@@ -702,6 +704,7 @@
 			/obj/item/assembly/signaler = -1,
 			/obj/item/binoculars = -1,
 			/obj/item/compass = -1,
+			/obj/item/stack/sandbags_empty/full = -1,
 		),
 	)
 
@@ -870,6 +873,7 @@
 			/obj/item/assembly/signaler = -1,
 			/obj/item/binoculars = -1,
 			/obj/item/compass = -1,
+			/obj/item/stack/sandbags_empty/full = -1,
 		),
 	)
 
@@ -1171,11 +1175,12 @@
 			/obj/item/stack/medical/heal_pack/gauze = -1,
 			/obj/item/stack/medical/heal_pack/ointment = -1,
 			/obj/item/stack/medical/splint = -1,
+			/obj/item/tweezers = -1,
 			/obj/item/stack/medical/heal_pack/advanced/bruise_pack = 50,
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 50,
 		),
 		"Misc" = list(
-			/obj/item/defibrillator = 8,
+			/obj/item/defibrillator = 10,
 			/obj/item/healthanalyzer = 16,
 			/obj/item/bodybag/cryobag = 24,
 			/obj/item/tool/surgery/solderingtool = 10,
@@ -1219,6 +1224,7 @@
 			/obj/item/stack/medical/heal_pack/advanced/bruise_pack = -1,
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = -1,
 			/obj/item/stack/medical/splint = -1,
+			/obj/item/tweezers = -1,
 		),
 		"Misc" = list(
 			/obj/item/healthanalyzer = -1,
@@ -1411,6 +1417,21 @@
 		"Freelancer" = list(
 			/obj/item/clothing/suit/storage/faction/freelancer = -1,
 			/obj/item/clothing/head/frelancer = -1,
+
+		),
+		"Mercenary" = list(
+			/obj/item/clothing/suit/storage/marine/veteran/wolves = -1,
+			/obj/item/clothing/suit/storage/marine/veteran/dutch = -1,
+			/obj/item/clothing/suit/storage/marine/veteran/mercenary = -1,
+			/obj/item/clothing/suit/storage/marine/veteran/mercenary/miner = -1,
+			/obj/item/clothing/suit/storage/marine/veteran/mercenary/engineer = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/dutch = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/dutch/cap = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/dutch/band = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/wolves = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/mercenary = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/mercenary/miner = -1,
+			/obj/item/clothing/head/helmet/marine/veteran/mercenary/engineer = -1,
 
 		),
 		"Civilian" = list(
@@ -1607,12 +1628,25 @@
 			/obj/item/clothing/under/marine/veteran/UPP = -1,
 			/obj/item/clothing/shoes/marine = -1,
 			/obj/item/storage/backpack/lightpack = -1,
+			/obj/item/clothing/mask/gas/PMC/upp = -1,
 		),
 		"Freelancer" = list(
 			/obj/item/clothing/gloves/marine/veteran/PMC = -1,
 			/obj/item/clothing/under/marine/veteran/freelancer = -1,
 			/obj/item/clothing/mask/rebreather/scarf/freelancer = -1,
-			/obj/item/clothing/shoes/marine = -1,
+			/obj/item/clothing/shoes/veteran/PMC = -1,
+			/obj/item/storage/backpack/lightpack = -1,
+		),
+		"Mercenary" = list(
+			/obj/item/clothing/gloves/marine/veteran/PMC = -1,
+			/obj/item/clothing/under/marine/veteran/wolves = -1,
+			/obj/item/clothing/under/marine/veteran/dutch = -1,
+			/obj/item/clothing/under/marine/veteran/dutch/ranger = -1,
+			/obj/item/clothing/under/marine/veteran/mercenary = -1,
+			/obj/item/clothing/under/marine/veteran/mercenary/miner = -1,
+			/obj/item/clothing/under/marine/veteran/mercenary/engineer = -1,
+			/obj/item/clothing/mask/gas/wolves = -1,
+			/obj/item/clothing/shoes/marine/clf/full = -1,
 			/obj/item/storage/backpack/lightpack = -1,
 		),
 		"Pizza time" = list(

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -291,6 +291,7 @@
 
 
 /obj/item/clothing/under/marine/veteran/dutch/ranger
+	name = "\improper Dutch's Dozen ranger uniform"
 	icon_state = "dutch_jumpsuit2"
 
 /*===========================HELGHAST - MERCENARY================================*/

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1054,14 +1054,6 @@ MEDICAL
 	containertype = /obj/structure/closet/crate/secure/surgery
 	access = ACCESS_MARINE_MEDBAY
 
-/datum/supply_packs/medical/tweezers
-	name = "tweezers"
-	notes = "contains a pair of tweezers."
-	contains = list(/obj/item/tweezers)
-	cost = 20  //shouldn't be easy to get
-	containertype = /obj/structure/closet/crate/secure/surgery
-	access = ACCESS_MARINE_MEDBAY
-
 /*******************************************************************************
 ENGINEERING
 *******************************************************************************/
@@ -1074,11 +1066,6 @@ ENGINEERING
 	contains = list(/obj/vehicle/ridden/powerloader)
 	cost = 20
 	containertype = null
-
-/datum/supply_packs/engineering/sandbags
-	name = "50 empty sandbags"
-	contains = list(/obj/item/stack/sandbags_empty/full)
-	cost = 10
 
 /datum/supply_packs/engineering/metal50
 	name = "50 metal sheets"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Balance-wise, this is largely meant to ease the burden of the relative few Engineer and Corpsman players in the faster-paced mission styles by giving PFCs more access to basic medical equipment and, particularly, reducing the time dedicated medical roles require to perform their duties. It also adds some more armor options that fit into the broader category of Mercenaries and tweaks some of the defensive equipment at the marines' disposal, halving the cost of barbed wire and making sandbags free from any weapons rack.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maybe now field hospitals other than (or in addition to) the tadpole will be somewhat viable to do. More teamwork is nice.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Squad Marine gains Metal level engineering skill, and the ability to use ATKs, defibs, tweezers, autodoc, and health analyzer without fumbling. Squad Leader now shares these medical skills.
balance: Squad Corpsman medical skills increased by 1. Gains special training in SMGs and pistols, allowing them to be used one-handed with greater effectiveness. Shipside doctor and CMO medical skills set to max.
balance: Squad Engineer gains special training in heavy weapons, such as Flamethrowers.
balance: Shrapnel removal time and damage caused are now divided by medical skill +1, meaning that higher skill equates to less damage taken. Ship docs and CMO do no damage when removing shrapnel, due to this.
balance: slight buff to first aid supplies: gauze/ointments now heal 5 damage up from 3, Advanced versions heal 15 up from 13
qol: Max amount for barbed wire stacks raised from 20 to 25
code: Merc veteran clothing and armors added to the respective vendors
balance: Tweezers are now stocked infinitely in marinemed, and no longer appear in Req. 
qol: Marinemed holds 2 additional defibs, for a total of 10
balance: Empty sandbags are now free in the Weapons Rack under Utility, and no longer appear in Req.
balance: Barbed wire now only costs 1 metal a piece. Razorwire costs 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
