### PR TITLE
Freelancer Kit!

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1529,6 +1529,23 @@ Imports
 	contains = list(/obj/item/ammo_magazine/rocket/som/thermobaric)
 	cost = 3
 
+/datum/supply_packs/imports/freelancertx55bundle
+	name = "AR-55 Rental pack"
+	contains = list(
+		/obj/item/weapon/gun/rifle/tx55/freelancer,
+		/obj/item/clothing/suit/storage/faction/freelancer/leader,
+		/obj/item/ammo_magazine/rifle/tx55,
+		/obj/item/ammo_magazine/rifle/tx55,
+		/obj/item/ammo_magazine/rifle/tx55,)
+	cost = 45
+
+/datum/supply_packs/imports/tx55ammo
+	name = "AR-55 Rental pack"
+	contains = list(
+		/obj/item/weapon/gun/rifle/tx55/freelancer)
+	cost = 5
+
+
 /datum/supply_packs/imports/carapace
 	name = "Imperial guard carapace armor"
 	contains = list(

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1496,6 +1496,22 @@ Imports
 	name = "Highpower Automag Ammo"
 	contains = list(/obj/item/ammo_magazine/pistol/highpower)
 	cost = 1
+	
+/datum/supply_packs/imports/freelancertx55bundle
+	name = "AR-55 Rental pack"
+	contains = list(
+		/obj/item/weapon/gun/rifle/tx55/freelancer,
+		/obj/item/clothing/suit/storage/faction/freelancer/leader,
+		/obj/item/ammo_magazine/rifle/tx55,
+		/obj/item/ammo_magazine/rifle/tx55,
+		/obj/item/ammo_magazine/rifle/tx55,)
+	cost = 45
+
+/datum/supply_packs/imports/tx55ammo
+	name = "AR-55 Rental pack"
+	contains = list(
+		/obj/item/weapon/gun/rifle/tx55/freelancer)
+	cost = 5
 
 /datum/supply_packs/imports/strawhat
 	name = "Straw hat"
@@ -1528,23 +1544,6 @@ Imports
 	name = "SOM RPG thermo warhead"
 	contains = list(/obj/item/ammo_magazine/rocket/som/thermobaric)
 	cost = 3
-
-/datum/supply_packs/imports/freelancertx55bundle
-	name = "AR-55 Rental pack"
-	contains = list(
-		/obj/item/weapon/gun/rifle/tx55/freelancer,
-		/obj/item/clothing/suit/storage/faction/freelancer/leader,
-		/obj/item/ammo_magazine/rifle/tx55,
-		/obj/item/ammo_magazine/rifle/tx55,
-		/obj/item/ammo_magazine/rifle/tx55,)
-	cost = 45
-
-/datum/supply_packs/imports/tx55ammo
-	name = "AR-55 Rental pack"
-	contains = list(
-		/obj/item/weapon/gun/rifle/tx55/freelancer)
-	cost = 5
-
 
 /datum/supply_packs/imports/carapace
 	name = "Imperial guard carapace armor"


### PR DESCRIPTION
## About The Pull Request

Adds a new fancy Freelancer styled kit to the Import section for 45 points. This includes a the TX-55, a few spare AR mags for it and the Freelancer leader's version of their vest, which comes with a Valkyrie module.

## Why It's Good For The Game

Well, it makes the TX-54 slightly more bareable? But aside from that, it gives an AR styled alternative to the V51B kit.

In terms of points, all the items in theory would add up to 47(Not counting the free extra 3 mags.), so it comes with a nice discount!

30 for the TX-54.
5 for the imported rifle.
12 for the Valkyrie module.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds a new supply pack.
/:cl:

