### PR TITLE
Various medical recipe changes. Adds Russian Red recipe.

### DIFF
--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -12,13 +12,14 @@
 /datum/chemical_reaction/dexalin
 	name = "Dexalin"
 	results = list(/datum/reagent/medicine/dexalin = 1)
-	required_reagents = list(/datum/reagent/oxygen = 2, /datum/reagent/toxin/phoron = 0.1)
+	required_reagents = list(/datum/reagent/oxygen = 2, /datum/reagent/iron = 1)
 	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
 /datum/chemical_reaction/dermalime
 	name = "Dermaline"
 	results = list(/datum/reagent/medicine/dermaline = 3)
-	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/phosphorus = 1, /datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/phosphorus = 1, /datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/clonexadone = 1)
+	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
 /datum/chemical_reaction/dexalinplus
 	name = "Dexalin Plus"
@@ -33,12 +34,13 @@
 /datum/chemical_reaction/meralyne
 	name = "Meralyne"
 	results = list(/datum/reagent/medicine/meralyne = 3)
-	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/iron = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/iron = 1, /datum/reagent/medicine/clonexadone = 1)
+	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"
 	results = list(/datum/reagent/medicine/ryetalyn = 2)
-	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/lemoline = 1)
+	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/carbon = 1, /datum/reagent/sterilizine = 1)
 
 /datum/chemical_reaction/cryoxadone
 	name = "Cryoxadone"
@@ -48,7 +50,7 @@
 /datum/chemical_reaction/clonexadone
 	name = "Clonexadone"
 	results = list(/datum/reagent/medicine/clonexadone = 2)
-	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/sodium = 1, /datum/reagent/toxin/phoron = 0.1)
+	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/sodium = 1, /datum/reagent/blood = 1)
 	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
 /datum/chemical_reaction/spaceacillin
@@ -142,7 +144,8 @@
 /datum/chemical_reaction/peridaxon_plus
 	name = "Peridaxon Plus"
 	results = list(/datum/reagent/medicine/peridaxon_plus = 1)
-	required_reagents = list(/datum/reagent/medicine/ryetalyn = 5, /datum/reagent/toxin/phoron = 5)
+	required_reagents = list(/datum/reagent/medicine/ryetalyn = 5, /datum/reagent/medicine/clonexadone = 5)
+	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
 /datum/chemical_reaction/quickclot
 	name = "Quick-Clot"
@@ -170,6 +173,12 @@
 	name = "Lemoline catalysis"
 	results = list(/datum/reagent/medicine/lemoline = 5) //4 to one multiplication ratio
 	required_reagents = list(/datum/reagent/medicine/lemoline = 1, /datum/reagent/consumable/larvajelly = 1)
+
+/datum/chemical_reaction/russian_red
+	name = "Russian Red"
+	results = list(/datum/reagent/medicine/russian_red = 6)//Combines all the physical damage healing chems with inaprovaline and opium. Lemoline no longer required, but is complicated and time consuming to make so that you don't have corpsmen filling their pill cases with nothing but Russian Red at roundstart.
+	required_reagents = list(/datum/chemical_reaction/bicaridine = 1, /datum/reagent/medicine/meralyne = 1, /datum/chemical_reaction/kelotane = 1, /datum/reagent/medicine/dermaline = 1, /datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/oxycodone = 1,)
+	required_catalysts = list(/datum/reagent/toxin/phoron = 5)//Prevents you and others from mixing it in your blood by accident and instantly overdosing.
 
 // Cloning chemicals
 /datum/chemical_reaction/expanded_biomass

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -568,7 +568,7 @@
 		L.jitter(10)
 		for(var/datum/internal_organ/I AS in H.internal_organs)
 			if(I.damage)
-				if(I.damage < 29)
+				if(I.damage > 29)//not a replacement for surgery or peridaxon in most cases, but can probably fix broken bones if you're in crit now.
 					return
 				I.heal_organ_damage((I.damage-29) *effect_str)
 		TIMER_COOLDOWN_START(L, name, 300 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Several medical chems require lemoline to make, which in turn can only be made by combining lemoline with larval jelly, which isn't really obtainable in our codebase, or by ordering it from req, which nobody bothers with doing. This PR alters several recipes to make them slightly less of a pain in the ass to mix, and even adds a recipe for Russian Red. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maybe shipdocs will have a reason to do chemistry now, and maybe corpsmen can refill their advanced meds either on the ship or in the groundmap medical lab.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Dexalin recipe now requires 1u of iron instead of 0.1 phoron. Catalyst unchanged.

qol: Dermaline and Meralyne recipes now require 1u clonexadone instead of 1u lemoline, and 5u phoron as a catalyst

qol: Ryetalyn recipe now requires 1u sterilizine instead of 1u lemoline.

qol: Clonexadone recipe now requires 1u of blood, instead of 0.1u of phoron.

qol: Peridaxon+ recipe now requires 5u clonexadone instead of 5u phoron, and must now be mixed in the presence of a 5u phoron catalyst.

add: Added a recipe for Russian Red requiring 1u each of bicaridine, meralyne, kelotane, dermaline, inaprovaline, and oxycodone in the presence of a 5u phoron catalyst, to produce 6u of Russian Red.

balance: Russian Red's bonus effect while in crit is altered; instead of healing organ damage only when it is below 29, it now only heals organ damage if it is above 29, meaning that it wont fix minor to moderate cases of organ damage, but can fix the broken bones of a freshly revived marine, or possibly a marine that has just gone into crit and by some miracle survives the ordeal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
