### PR TITLE
Updates one line for the Man at Arms, allowing for fast plasteel repairs.

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -208,7 +208,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	cqc = SKILL_CQC_MP
 	police = SKILL_POLICE_MP
 	construction = SKILL_CONSTRUCTION_METAL
-	engineer = SKILL_ENGINEER_METAL
+	engineer = SKILL_ENGINEER_ENGI
 	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_TRAINED
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the Standard Man at Arms to have engi engi skill. Meaning they can repair plasteel cades without fumbling, etc, etc.

## Why It's Good For The Game

I 'unno, I don't play the role. The others said it was a good idea.
