### PR TITLE
Updates the AR55 pack's pricing for the unteenth time.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1505,7 +1505,7 @@ Imports
 		/obj/item/ammo_magazine/rifle/tx55,
 		/obj/item/ammo_magazine/rifle/tx55,
 		/obj/item/ammo_magazine/rifle/tx55,)
-	cost = 45
+	cost = 20
 
 /datum/supply_packs/imports/tx55/ammo
 	name = "AR-55 Carbine ammo."


### PR DESCRIPTION
## About The Pull Request

As the Leader freelancer armor is no longer different to the standard variant, the price should reflect that.

We could've put the valk back on but uh...Then we'd just be with a cheaper B18.

## Why It's Good For The Game

You still get a beret that's armored. That's good, right?