### PR TITLE
Reverts a sandbagged change to the SH-35

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -292,7 +292,7 @@
 	cock_locked_message = "The pump is locked! Fire it first!"
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 10, "rail_y" = 21, "under_x" = 20, "under_y" = 14, "stock_x" = 20, "stock_y" = 14)
 
-	fire_delay = 1.4 SECONDS
+	fire_delay = 1 SECONDS
 	damage_mult = 2
 	scatter_unwielded = 10
 	damage_falloff_mult = 1
@@ -339,7 +339,7 @@
 		/obj/item/attachable/stock/irremoveable/pal12,
 	)
 
-	fire_delay = 1.5 SECONDS
+	fire_delay = 1 SECONDS
 	damage_mult = 2.2
 	accuracy_mult = 1
 	damage_falloff_mult = 1
@@ -694,7 +694,7 @@
 	fire_delay = 0.4 SECONDS //If your muscle memory is good enough, it's almost like slamfire. Still not quite as fast as other shotguns.
 	scatter_unwielded = 10
 	damage_falloff_mult = 1
-	damage_mult = 2
+	damage_mult = 1.25
 	recoil = -1
 	recoil_unwielded = 4
 	aim_slowdown = 0.45

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -691,7 +691,7 @@
 
 	flags_item_map_variant = NONE
 
-	fire_delay = 1.4 SECONDS //If your muscle memory is good enough, it's almost like slamfire. Still not quite as fast as other shotguns. (NOT ANYMORE!!!!!!!)
+	fire_delay = 0.4 SECONDS //If your muscle memory is good enough, it's almost like slamfire. Still not quite as fast as other shotguns.
 	scatter_unwielded = 10
 	damage_falloff_mult = 1
 	damage_mult = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In the recent 'Great Respritening' PR by Davidththird, without proper documentation, not only took it upon himself to nerf the firedelay of the SH-35 to 1.4 seconds between shots instead of 0.4, but also decided to be snarky about it in the inline comment when it was changed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In order to enforce proper coder ettiquette, this salt PR change sandbagged within in a visual rework should be reverted. Buckshot and damage multiplier were already reduced by Jasmine to bring shotguns into an acceptable state of balance and this fire delay nerf was discussed openly with no-one.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: reverts an undiscussed salt-PR nerf to the SH-35
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
