### PR TITLE
Adds a new ERT dropship variant

### DIFF
--- a/_maps/shuttles/distress_upgrade.dmm
+++ b/_maps/shuttles/distress_upgrade.dmm
@@ -1,0 +1,378 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan20"
+	},
+/area/shuttle/ert/supply)
+"c" = (
+/obj/docking_port/mobile/ert,
+/turf/closed/shuttle/ert{
+	icon_state = "stan27"
+	},
+/area/shuttle/ert/supply)
+"d" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan25"
+	},
+/area/shuttle/ert/supply)
+"e" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan21"
+	},
+/area/shuttle/ert/supply)
+"f" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan22"
+	},
+/area/shuttle/ert/supply)
+"g" = (
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"h" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan23"
+	},
+/area/shuttle/ert/supply)
+"i" = (
+/turf/closed/shuttle/ert,
+/area/shuttle/ert/supply)
+"k" = (
+/obj/machinery/vending/nanomed,
+/turf/open/shuttle/dropship{
+	icon_state = "rasputin6"
+	},
+/area/shuttle/ert/supply)
+"l" = (
+/turf/open/shuttle/dropship{
+	icon_state = "floor8"
+	},
+/area/shuttle/ert/supply)
+"m" = (
+/obj/machinery/vending/nanomed,
+/turf/open/shuttle/dropship/seven,
+/area/shuttle/ert/supply)
+"n" = (
+/obj/effect/landmark/distress_item,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"o" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan5"
+	},
+/area/shuttle/ert/supply)
+"p" = (
+/obj/machinery/door/poddoor/shutters/transit/open,
+/obj/machinery/door/airlock/mainship/generic/ert,
+/turf/open/shuttle/dropship/three,
+/area/shuttle/ert/supply)
+"s" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/effect/landmark/distress,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"t" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/effect/landmark/distress,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"u" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/regular,
+/obj/item/ammo_magazine/dual_cannon,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"v" = (
+/turf/open/shuttle/dropship{
+	icon_state = "rasputin4"
+	},
+/area/shuttle/ert/supply)
+"w" = (
+/turf/open/shuttle/dropship/eight,
+/area/shuttle/ert/supply)
+"x" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_leftengine"
+	},
+/area/shuttle/ert/supply)
+"y" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan8"
+	},
+/area/shuttle/ert/supply)
+"z" = (
+/turf/open/shuttle/dropship/three,
+/area/shuttle/ert/supply)
+"A" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan9"
+	},
+/area/shuttle/ert/supply)
+"B" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_rightengine"
+	},
+/area/shuttle/ert/supply)
+"C" = (
+/obj/effect/landmark/distress_item,
+/turf/open/shuttle/dropship/three,
+/area/shuttle/ert/supply)
+"D" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/distress_item,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"E" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/distress_item,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"F" = (
+/obj/machinery/computer/communications,
+/obj/structure/table/reinforced,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"G" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert/supply)
+"H" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan1"
+	},
+/area/shuttle/ert/supply)
+"I" = (
+/obj/machinery/door/poddoor/shutters/transit/open{
+	dir = 2
+	},
+/obj/machinery/door/airlock/mainship/generic/ert{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"J" = (
+/obj/machinery/door/poddoor/shutters/transit/open{
+	dir = 2
+	},
+/obj/item/weapon/gun/dual_cannon,
+/turf/open/shuttle/dropship/three,
+/area/shuttle/ert/supply)
+"K" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan3"
+	},
+/area/shuttle/ert/supply)
+"L" = (
+/obj/machinery/door/poddoor/shutters/transit/open{
+	dir = 2
+	},
+/obj/item/weapon/gun/dual_cannon{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"M" = (
+/obj/machinery/door/poddoor/shutters/transit/open{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"N" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert/supply)
+"O" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert/supply)
+"P" = (
+/obj/machinery/door/poddoor/shutters/transit/open{
+	dir = 2
+	},
+/obj/item/weapon/gun/dual_cannon{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"Q" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert/supply)
+"R" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert/supply)
+"S" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert/supply)
+"U" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/effect/landmark/distress,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"V" = (
+/obj/machinery/autodoc,
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+"W" = (
+/obj/machinery/door/poddoor/shutters/transit/open{
+	dir = 2
+	},
+/turf/open/shuttle/dropship/three,
+/area/shuttle/ert/supply)
+"X" = (
+/obj/structure/bed/chair/dropship/pilot{
+	dir = 1
+	},
+/turf/open/shuttle/dropship{
+	icon_state = "floor8"
+	},
+/area/shuttle/ert/supply)
+"Y" = (
+/obj/machinery/autodoc_console,
+/turf/open/shuttle/dropship/three,
+/area/shuttle/ert/supply)
+"Z" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/effect/landmark/distress,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/shuttle/ert/supply)
+
+(1,1,1) = {"
+a
+b
+i
+p
+i
+P
+i
+p
+i
+x
+G
+O
+R
+"}
+(2,1,1) = {"
+a
+e
+Z
+g
+s
+g
+s
+g
+u
+y
+i
+i
+H
+"}
+(3,1,1) = {"
+b
+f
+k
+z
+z
+z
+z
+z
+v
+M
+D
+n
+I
+"}
+(4,1,1) = {"
+c
+F
+X
+n
+n
+n
+n
+V
+l
+W
+C
+C
+J
+"}
+(5,1,1) = {"
+d
+h
+m
+z
+z
+z
+z
+Y
+w
+M
+E
+n
+I
+"}
+(6,1,1) = {"
+a
+e
+U
+g
+t
+g
+t
+g
+u
+A
+o
+o
+K
+"}
+(7,1,1) = {"
+a
+d
+o
+p
+o
+L
+o
+p
+o
+B
+N
+S
+Q
+"}

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -112,6 +112,7 @@
 #define SHUTTLE_DISTRESS_UFO "distress_ufo"
 #define SHUTTLE_DISTRESS_UPP "distress_upp"
 #define SHUTTLE_DISTRESS_PMC "distress_pmc"
+#define SHUTTLE_DISTRESS_SUPPLY "distress_upgrade"
 #define SHUTTLE_DISTRESS "distress"
 #define SHUTTLE_ESCAPE_POD "escape_pod"
 #define SHUTTLE_SUPPLY "supply"

--- a/code/datums/emergency_calls/supplies.dm
+++ b/code/datums/emergency_calls/supplies.dm
@@ -38,11 +38,12 @@
 
 
 /datum/emergency_call/supplies
-	name = "Supply Drop"
+	name = "Supply Drop (And a modified shuttle!)"
 	mob_max = 0
 	mob_min = 0
 	base_probability = 0
-	auto_shuttle_launch = TRUE
+	auto_shuttle_launch = FALSE
+	shuttle_id = SHUTTLE_DISTRESS_SUPPLY
 
 
 /datum/emergency_call/supplies/spawn_items()

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -132,6 +132,10 @@
 	shuttle_id = SHUTTLE_DISTRESS
 	name = "Distress"
 
+/datum/map_template/shuttle/small_ert/supply
+	shuttle_id = SHUTTLE_DISTRESS_SUPPLY
+	name = "Modified Distress Shuttle"
+
 /datum/map_template/shuttle/small_ert/pmc
 	shuttle_id = SHUTTLE_DISTRESS_PMC
 	name = "Distress PMC"

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -58,6 +58,9 @@
 /area/shuttle/ert/pmc
 	name = "PMC ERT"
 
+/area/shuttle/ert/supply
+	name = "ERT Gunship"
+
 /area/shuttle/big_ert
 	name = "Big ERT Ship"
 

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -113,6 +113,9 @@
 /obj/effect/attach_point/crew_weapon/minidropship
 	ship_tag = SHUTTLE_TADPOLE
 
+/obj/effect/attach_point/crew_weapon/distress
+	ship_tag = SHUTTLE_DISTRESS_SUPPLY
+
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = SHUTTLE_ALAMO
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Been trying map stuff recently. Might be useful to use in certain missions, as normally if you'd delete a wall, the floor would never return.

You can access this dropship variant trough the supply ERT.

## Why It's Good For The Game

Well. It allows for more variety with dropships!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
