### PR TITLE
Adds Huldra Autorepair module

### DIFF
--- a/code/datums/components/suit_autorepair.dm
+++ b/code/datums/components/suit_autorepair.dm
@@ -1,0 +1,134 @@
+
+/datum/component/suit_autorepair
+	var/obj/item/healthanalyzer/integrated/analyzer
+	var/enabled = FALSE
+	var/mob/living/carbon/wearer
+	var/datum/action/suit_autodoc/toggle/toggle_action
+	var/datum/action/suit_autodoc/scan/scan_action
+
+/datum/component/suit_autorepair/Initialize()
+	if(!istype(parent, /obj/item))
+		return COMPONENT_INCOMPATIBLE
+
+	analyzer = new
+
+/datum/component/suit_autorepair/Destroy(force, silent)
+	QDEL_NULL(analyzer)
+	QDEL_NULL(toggle_action)
+	QDEL_NULL(scan_action)
+	wearer = null
+	return ..()
+
+/datum/component/suit_autorepair/RegisterWithParent()
+	. = ..()
+	toggle_action = new(parent)
+	scan_action = new(parent)
+	RegisterSignal(parent, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED), .proc/dropped)
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED_TO_SLOT, .proc/equipped)
+	RegisterSignal(toggle_action, COMSIG_ACTION_TRIGGER, .proc/action_toggle)
+	RegisterSignal(scan_action, COMSIG_ACTION_TRIGGER, .proc/scan_user)
+
+/datum/component/suit_autorepair/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, list(
+		COMSIG_PARENT_EXAMINE,
+		COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT,
+		COMSIG_ITEM_DROPPED,
+		COMSIG_ITEM_EQUIPPED_TO_SLOT))
+	QDEL_NULL(toggle_action)
+	QDEL_NULL(scan_action)
+
+/datum/component/suit_autorepair/proc/dropped(datum/source, mob/user)
+	SIGNAL_HANDLER
+	if(!iscarbon(user))
+		return
+	remove_actions()
+	disable()
+	wearer = null
+
+/datum/component/suit_autorepair/proc/equipped(datum/source, mob/equipper, slot)
+	SIGNAL_HANDLER
+	if(!iscarbon(equipper)) // living can equip stuff but only carbon has traumatic shock
+		return
+	wearer = equipper
+	enable()
+	give_actions()
+
+/datum/component/suit_autorepair/proc/disable(silent = FALSE)
+	if(!enabled)
+		return
+	enabled = FALSE
+	toggle_action.set_toggle(FALSE)
+	STOP_PROCESSING(SSobj, src)
+	if(!silent)
+		wearer.balloon_alert(wearer, "The autorepair suite deactivates")
+		playsound(parent,'sound/machines/click.ogg', 15, 0, 1)
+
+/datum/component/suit_autorepair/proc/enable(silent = FALSE)
+	if(enabled)
+		return
+	enabled = TRUE
+	toggle_action.set_toggle(TRUE)
+	START_PROCESSING(SSobj, src)
+	if(!silent)
+		wearer.balloon_alert(wearer, "The autorepair suite activates")
+		playsound(parent,'sound/voice/b18_activate.ogg', 15, 0, 1)
+
+/datum/component/suit_autorepair/proc/give_actions()
+	toggle_action.give_action(wearer)
+	scan_action.give_action(wearer)
+
+/datum/component/suit_autorepair/proc/remove_actions()
+	if(!wearer)
+		return
+	toggle_action.remove_action(wearer)
+	scan_action.remove_action(wearer)
+
+/datum/component/suit_autorepair/proc/action_toggle(datum/source)
+	SIGNAL_HANDLER
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_TOGGLE))
+		return
+	TIMER_COOLDOWN_START(src, COOLDOWN_TOGGLE, 2 SECONDS)
+	if(enabled)
+		disable()
+	else
+		enable()
+
+/datum/component/suit_autodoc/can_interact(mob/user)
+	return TRUE
+
+/datum/component/suit_autorepair/proc/scan_user(datum/source)
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(analyzer, /obj/item.proc/attack, wearer, wearer, TRUE)
+
+/datum/component/suit_autorepair/process()
+	repair_wearer()
+
+/datum/component/suit_autorepair/proc/repair_wearer()
+	if(!wearer)
+		CRASH("attempting to repair_wearer with no wearer")
+	if(!(wearer.species.species_flags & ROBOTIC_LIMBS))
+		return
+	if(wearer.health < wearer.maxHealth)
+		wearer.heal_overall_damage(4, 4, TRUE, TRUE)
+		playsound(src, 'sound/items/ratchet.ogg', 25)
+
+/datum/action/suit_autorepair
+	action_icon = 'icons/mob/screen_alert.dmi'
+
+/datum/action/suit_autorepair/can_use_action()
+	if(QDELETED(owner) || owner.incapacitated() || owner.lying_angle)
+		return FALSE
+	return TRUE
+
+/datum/action/suit_autorepair/toggle
+	name = "Toggle Suit Autorepair"
+	action_icon_state = "suit_toggle"
+	action_type = ACTION_TOGGLE
+
+/datum/action/suit_autorepair/scan
+	name = "User Medical Scan"
+	action_icon_state = "suit_scan"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_KB_SUITANALYZER,
+	)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -587,3 +587,24 @@
 	SIGNAL_HANDLER
 	beacon_datum = null
 
+/obj/item/armor_module/module/huldra_autorepair
+	name = "\improper Huldra Autorepair System"
+	icon = 'icons/mob/modular/modular_armor_modules.dmi'
+	desc = "Designed for mounting on modular robot armor. This module will swiftly and automatically repair the mechanical components of the wearer, and the hydraulic frame stabilizes damaged limbs. Will definitely impact mobility."
+	icon_state = "mod_autodoc"
+	item_state = "mod_autodoc_a"
+	slowdown = 0.3
+	slot = ATTACHMENT_SLOT_MODULE
+	variants_by_parent_type = list(/obj/item/clothing/suit/modular/xenonauten = "mod_autodoc_xn", /obj/item/clothing/suit/modular/xenonauten/light = "mod_autodoc_xn", /obj/item/clothing/suit/modular/xenonauten/heavy = "mod_autodoc_xn")
+	var/static/list/supported_limbs = list(CHEST, GROIN, ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT, LEG_LEFT, LEG_RIGHT, FOOT_LEFT, FOOT_RIGHT)
+
+/obj/item/armor_module/module/huldra_autorepair/on_attach(obj/item/attaching_to, mob/user)
+	. = ..()
+	parent.AddComponent(/datum/component/suit_autorepair)
+	parent.AddElement(/datum/element/limb_support, supported_limbs)
+
+
+/obj/item/armor_module/module/huldra_autorepair/on_detach(obj/item/detaching_from, mob/user)
+	qdel(parent.GetComponent(/datum/component/suit_autorepair))
+	parent.RemoveElement(/datum/element/limb_support, supported_limbs)
+	return ..()

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -1021,6 +1021,7 @@
 		/obj/item/armor_module/module/eshield,
 		/obj/item/armor_module/module/eshield/mk2,
 		/obj/item/armor_module/module/fire_proof/mk2,
+		/obj/item/armor_module/module/huldra_autorepair,
 
 		/obj/item/armor_module/storage/general,
 		/obj/item/armor_module/storage/ammo_mag,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -927,6 +927,13 @@ ARMOR
 	)
 	cost = 12
 
+/datum/supply_packs/armor/modular/attachments/huldra_autorepair
+	name = "Golem Huldra autorepair module"
+	contains = list(
+		/obj/item/armor_module/module/huldra_autorepair,
+	)
+	cost = 15
+
 /datum/supply_packs/armor/modular/attachments/eshield
 	name = "Jaeger Arrowhead mk.2"
 	contains = list(

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -357,6 +357,7 @@
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stamina_behavior.dm"
 #include "code\datums\components\suit_autodoc.dm"
+#include "code\datums\components\suit_autorepair.dm"
 #include "code\datums\components\throw_parry.dm"
 #include "code\datums\components\udder.dm"
 #include "code\datums\components\riding\riding.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Huldra Autorepair module is a new design in a similar vein to the Valkyrie Automedic, designed exclusively for use by TGMC combat robots.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Besides being a requested feature for some time now, the Huldra grants a heal over time to robots that is comparable to the classic Bicaridine Kelotane Tricordrazine Tramadol premed mix that human marines enjoy the use of. Unlike BKTT, the Huldra is only accessible from Req, with a 15 point price tag. This cheap price is to offset the fact that humans have access to good regenerative chems from the get-go.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Huldra Autorepair module, available from req.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
