### PR TITLE
Barricade QoL and Durability update

### DIFF
--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -54,7 +54,7 @@
 	throwforce = 10
 	throw_range = 5
 	attack_verb = list("hit", "whacked", "sliced")
-	max_amount = 10
+	max_amount = 25
 	merge_type = /obj/item/stack/razorwire
 
 
@@ -68,7 +68,7 @@
 
 //full stack
 /obj/item/stack/razorwire/full
-	amount = 20
+	amount = 25
 
 /obj/item/stack/razorwire/attack_self(mob/user) //use barbed wire to deploy it
 	if(!ishuman(usr))

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -15,9 +15,9 @@
 	var/dirt_overlay = "shovel_overlay"
 	var/folded = FALSE
 	var/dirt_type = NO_DIRT // 0 for no dirt, 1 for brown dirt, 2 for snow, 3 for big red, 4 for basalt(lava-land).
-	var/shovelspeed = 15
+	var/shovelspeed = 5
 	var/dirt_amt = 0
-	var/dirt_amt_per_dig = 5
+	var/dirt_amt_per_dig = 10
 
 /obj/item/tool/shovel/update_overlays()
 	. = ..()
@@ -140,7 +140,7 @@
 	folded = TRUE
 	dirt_overlay = "etool_overlay"
 	dirt_amt_per_dig = 5
-	shovelspeed = 20
+	shovelspeed = 10
 
 /obj/item/tool/shovel/etool/update_icon_state()
 	if(!folded && !sharp)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -305,6 +305,7 @@
 		"Utility" = list(
 			/obj/item/flashlight/combat = -1,
 			/obj/item/weapon/gun/grenade_launcher/single_shot/flare/marine = -1,
+			/obj/item/tool/shovel = -1,
 			/obj/item/tool/shovel/etool = -1,
 			/obj/item/tool/extinguisher = -1,
 			/obj/item/tool/extinguisher/mini = -1,
@@ -313,6 +314,8 @@
 			/obj/item/compass = -1,
 			/obj/item/tool/hand_labeler = -1,
 			/obj/item/stack/sandbags_empty/full = -1,
+			/obj/item/stack/barbed_wire/full = -1,
+			/obj/item/stack/razorwire/full = -1,
 			/obj/item/book/manual/ordtech = -1,
 		),
 	)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -443,7 +443,7 @@
 	desc = "A sturdy and easily assembled barricade made of metal plates, often used for quick fortifications. Use a blowtorch to repair."
 	icon_state = "metal_0"
 	max_integrity = 200
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "fire" = 80, "acid" = 40)
+	soft_armor = list("melee" = 50, "bullet" = 75, "laser" = 50, "energy" = 50, "bomb" = 30, "bio" = 100, "fire" = 100, "acid" = 50)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/metal
 	stack_amount = 4
@@ -540,12 +540,14 @@
 		if(CADE_TYPE_BOMB)
 			soft_armor = soft_armor.modifyRating(bomb = 50)
 		if(CADE_TYPE_MELEE)
-			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 30)
+			soft_armor = soft_armor.modifyRating(melee = 30, bullet = 20)
 		if(CADE_TYPE_ACID)
-			soft_armor = soft_armor.modifyRating(acid = 20)
+			soft_armor = soft_armor.modifyRating(acid = 30)
 			resistance_flags |= UNACIDABLE
 
 	barricade_upgrade_type = choice
+
+	modify_max_integrity(max_integrity + 300)
 
 	balloon_alert_to_viewers("[choice] attached")
 
@@ -757,9 +759,9 @@
 				if(CADE_TYPE_BOMB)
 					soft_armor = soft_armor.modifyRating(bomb = -50)
 				if(CADE_TYPE_MELEE)
-					soft_armor = soft_armor.modifyRating(melee = -30, bullet = -30)
+					soft_armor = soft_armor.modifyRating(melee = -30, bullet = -20)
 				if(CADE_TYPE_ACID)
-					soft_armor = soft_armor.modifyRating(acid = -20)
+					soft_armor = soft_armor.modifyRating(acid = -30)
 					resistance_flags &= ~UNACIDABLE
 
 			new /obj/item/stack/sheet/metal(loc, CADE_UPGRADE_REQUIRED_SHEETS)
@@ -797,7 +799,7 @@
 	desc = "A very sturdy barricade made out of plasteel panels, the pinnacle of strongpoints. Use a blowtorch to repair. Can be flipped down to create a path."
 	icon_state = "plasteel_closed_0"
 	max_integrity = 500
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "fire" = 80, "acid" = 40)
+	soft_armor = list("melee" = 50, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 50, "bio" = 100, "fire" = 100, "acid" = 50)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/plasteel
 	stack_amount = 5
@@ -1061,7 +1063,7 @@
 	desc = "A bunch of bags filled with sand, stacked into a small wall. Surprisingly sturdy, albeit labour intensive to set up. Trusted to do the job since 1914."
 	icon_state = "sandbag_0"
 	max_integrity = 300
-	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "fire" = 80, "acid" = 40)
+	soft_armor = list("melee" = 60, "bullet" = 95, "laser" = 95, "energy" = 95, "bomb" = 80, "bio" = 100, "fire" = 100, "acid" = 60)
 	coverage = 128
 	stack_type = /obj/item/stack/sandbags
 	hit_sound = "sound/weapons/genhit.ogg"
@@ -1131,7 +1133,7 @@
 	barricade_type = "folding"
 	can_wire = TRUE
 	is_wired = FALSE
-	soft_armor = list(MELEE = 35, BULLET = 30, LASER = 20, ENERGY = 40, BOMB = 25, BIO = 100, FIRE = 100, ACID = 30)
+	soft_armor = list(MELEE = 90, BULLET = 90, LASER = 90, ENERGY = 90, BOMB = 80, BIO = 100, FIRE = 100, ACID = 70)
 	///Whether this item can be deployed or undeployed
 	var/flags_item = IS_DEPLOYABLE
 	///What it deploys into. typecast version of internal_item


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The objective of this update is to accomplish a short list of things. These follow:

1. Give barricades some actual base armor values, both due to the propensity for their destruction by even slightly stray bullets, and due to the massive increase in health across T2 and T3 castes drastically increasing the guaranteed damage that can be done during wave defense, as the map is flooded with dozens or even hundreds of angry 'minibosses,' as the host is fond of calling them.

2. Make metal barricades, particularly upgraded ones, worth using over free sandbags. This should encourage marines to have a strong backline of reinforced metal cades at FOB, while using sandbags for most other fortification needs.

3. Make barbed wire and razorwire freely available. Barbed wire adds a bit of health to cades, makes things that attack them in melee damage themselves, and prevents xenos from leaping over them. Razorwire acts as a cheap, disposable barrier along the outsides of barricade lines, and can be electrified if engineers bother to expand the wirenets to accommodate them. Making these free alongside sandbags encourages marines to turn surrounding buildings into fortresses, which can be great when attempting to hold locations for objectives, or for making durable fallback points if they start taking casualties.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It allows marines to more reliably put down defenses in any section of the map, which can also give the admemes more flexibility with objectives and allowing for new strategies surrounding them.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Shovels can hold 10 dirt per dig, and are twice as fast as e-tools, since they can't be folded. E-tools have had their work speed doubled, making them viable for marines to take when setting up for distant point holds relative to LZ.
balance: Metal, sandbag, and plasteel barricades now have increased armor against all damage types across the board. Sandbag barricades have melee and acid armor that is between basic metal and plasteel, but significantly less than upgraded metal. Upgraded metal has as much integrity as plasteel, but its armor depends on upgrade type. Experiment with FOB designs! Plasteel has great armor across the board, and would be best in class if it weren't so expensive. Sandbags, ballistic metal, and plasteel are also now much more resilient against marine weapons, making stray bullets less liable to fuck over wave defense.
balance: Makes barbed wire and razorwire free from the Utility tab, making it possible to quickly plug holes in cadelines against straggling swarmers while performing repairs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
