### PR TITLE
Buffs shovel workspeeds, makes barbed wire and razor wire free.

### DIFF
--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -14,6 +14,7 @@
 	attack_verb = list("hit", "whacked", "sliced")
 	max_amount = 25
 	merge_type = /obj/item/stack/barbed_wire
+	materials = list()
 
 //small stack
 /obj/item/stack/barbed_wire/small_stack
@@ -56,6 +57,7 @@
 	attack_verb = list("hit", "whacked", "sliced")
 	max_amount = 10
 	merge_type = /obj/item/stack/razorwire
+	materials = list()
 
 
 //small stack

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -15,9 +15,9 @@
 	var/dirt_overlay = "shovel_overlay"
 	var/folded = FALSE
 	var/dirt_type = NO_DIRT // 0 for no dirt, 1 for brown dirt, 2 for snow, 3 for big red, 4 for basalt(lava-land).
-	var/shovelspeed = 15
+	var/shovelspeed = 5
 	var/dirt_amt = 0
-	var/dirt_amt_per_dig = 5
+	var/dirt_amt_per_dig = 10
 
 /obj/item/tool/shovel/update_overlays()
 	. = ..()
@@ -140,7 +140,7 @@
 	folded = TRUE
 	dirt_overlay = "etool_overlay"
 	dirt_amt_per_dig = 5
-	shovelspeed = 20
+	shovelspeed = 10
 
 /obj/item/tool/shovel/etool/update_icon_state()
 	if(!folded && !sharp)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -305,6 +305,7 @@
 		"Utility" = list(
 			/obj/item/flashlight/combat = -1,
 			/obj/item/weapon/gun/grenade_launcher/single_shot/flare/marine = -1,
+			/obj/item/tool/shovel = -1,
 			/obj/item/tool/shovel/etool = -1,
 			/obj/item/tool/extinguisher = -1,
 			/obj/item/tool/extinguisher/mini = -1,
@@ -313,6 +314,8 @@
 			/obj/item/compass = -1,
 			/obj/item/tool/hand_labeler = -1,
 			/obj/item/stack/sandbags_empty/full = -1,
+			/obj/item/stack/barbed_wire/full = -1,
+			/obj/item/stack/razorwire/full = -1,
 			/obj/item/book/manual/ordtech = -1,
 		),
 	)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -166,7 +166,6 @@
 	can_wire = FALSE
 	is_wired = TRUE
 	climbable = FALSE
-	modify_max_integrity(max_integrity + 50)
 	update_icon()
 
 /obj/structure/barricade/wirecutter_act(mob/living/user, obj/item/I)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -18,20 +18,6 @@
 	max_integrity = RAZORWIRE_MAX_HEALTH
 	var/soak = 5
 
-/obj/structure/razorwire/deconstruct(disassembled = TRUE)
-	if(disassembled)
-		if(obj_integrity > max_integrity * 0.5)
-			new sheet_type(loc)
-		var/obj/item/stack/rods/salvage = new sheet_type2(loc)
-		salvage.amount = min(1, round(4 * (obj_integrity / max_integrity) ) )
-	else
-		if(prob(50))
-			new sheet_type(loc)
-		if(prob(50))
-			var/obj/item/stack/rods/salvage = new sheet_type2(loc)
-			salvage.amount = rand(1,4)
-	return ..()
-
 /obj/structure/razorwire/Initialize()
 	. = ..()
 	var/static/list/connections = list(


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
My proposed buffs to the resilience of cades were not well-received, but these QoL changes, apart from that failed project, could still make defense objectives a bit more fun without making them unchallenging, so there are no durability changes in this PR.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It would be nice to see razorwire and barbed wire used more across all mission types, and it would also be nice if sandbags were less time-consuming to prepare.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: entrenching tools now dig twice as fast. Full-size shovels now hold 10 dirt and dig twice as fast as E-tools.
balance: Barbed wire and razorwire are now free in the Utility tab, making it a little bit more possible to repair cade-lines between waves, or to set up some defenses around a held objective.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
