### PR TITLE
Valkyrie mod has its own autodoc subtype, autodoc now has emergency chems for a critical patient.

### DIFF
--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -60,10 +60,6 @@
 		/datum/reagent/medicine/tramadol)
 	var/static/list/default_emergency_chems = list(
 		/datum/reagent/medicine/inaprovaline,
-		/datum/reagent/medicine/meralyne,
-		/datum/reagent/medicine/dermaline,
-		/datum/reagent/medicine/dexalinplus,
-		/datum/reagent/medicine/hyronalin,
 		)
 
 	var/datum/action/suit_autodoc/toggle/toggle_action

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -36,16 +36,13 @@
 
 /obj/item/armor_module/module/valkyrie_autodoc/on_attach(obj/item/attaching_to, mob/user)
 	. = ..()
-	var/list/tricord = list(/datum/reagent/medicine/tricordrazine)
-	var/list/tramadol = list(/datum/reagent/medicine/tramadol)
-	var/list/russian_red = list(/datum/reagent/medicine/russian_red)
-	/// This will do nothing without the autodoc update
-	parent.AddComponent(/datum/component/suit_autodoc, 4 MINUTES, tricord, tricord, tricord, tricord, russian_red, tramadol, 0.5)
+	/// Valk now has its own subtype of autodoc
+	parent.AddComponent(/datum/component/suit_autodoc/module)
 	parent.AddElement(/datum/element/limb_support, supported_limbs)
 
 
 /obj/item/armor_module/module/valkyrie_autodoc/on_detach(obj/item/detaching_from, mob/user)
-	qdel(parent.GetComponent(/datum/component/suit_autodoc))
+	qdel(parent.GetComponent(/datum/component/suit_autodoc/module))
 	parent.RemoveElement(/datum/element/limb_support, supported_limbs)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
JasRick asked me to take a look at the autodoc since a recent change to it caused it to break for unclear reasons. In order to achieve the goal of those changes, I refactored how it was handled. In the process, I also added a new feature, namely a category of chems that can be injected only once the wearer is in crit. For the purposes of the Valkyrie module, I made it use Inaprovaline and Russian Red at this threshold.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The addition of Russian Red to the Valkyrie module was an attempted and approved change, but it didn't function as planned. I've not only fixed that issue, but improved the system.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new list of injectable chems for the standard armor autodoc. By default, when health falls below -50, this autodoc will inject Meralyne, Dermaline, Hyronalin, Dexalin Plus, and Inaprovaline.
refactor: Valkyrie module now has its own subtype of autodoc component.
fix: Valkyrie once again correctly injects chemicals when crossing damage thresholds.
balance: Valkyrie module now acts more like its namesake, injecting a dose of Russian Red and inaprovaline on crit instead of the advanced chems of its parent component. Cooldown on injections in each category is 5 minutes due to the strength and chemical complexity of Russian Red.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
