### PR TITLE
quick fix for 7.62x54 in marksman belt.

### DIFF
--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -686,7 +686,7 @@
 /datum/ammopacktype/p762x54
 	default_ammo = /obj/item/ammo_magazine/sniper/svd
 	max_rounds = 600 // 20 magazines' worth of ammo
-	caliber = CALIBER_762X39
+	caliber = CALIBER_762X54
 	radial_icon = 'icons/mob/radial.dmi'
 	radial_icon_state = "box_762x54mm"
 	caliber_label = "7.62x54mm Rimfire"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug where SVD ammo isn't accepted by the T-74 belt
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The ammo type datum for 7.62x54mmR now has the correct caliber.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
